### PR TITLE
encoded non string data

### DIFF
--- a/pkg/amqp/marshaler_test.go
+++ b/pkg/amqp/marshaler_test.go
@@ -1,6 +1,8 @@
 package amqp_test
 
 import (
+	"bytes"
+	"encoding/gob"
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill"
@@ -94,6 +96,64 @@ func TestDefaultMarshaler_postprocess_publishing(t *testing.T) {
 	assert.Equal(t, marshaled.ContentType, "application/json")
 }
 
+func TestDefaultMarshaler_encoding_non_string_values(t *testing.T) {
+	marshaler := amqp.DefaultMarshaler{}
+	delivery := createDelivery(map[string]interface{}{
+		"foo":     "bar",
+		"x-death": []interface{}{"foo", 2, true, []interface{}{"inside"}},
+		"int":     int64(3),
+		"bool":    true,
+	})
+	unmarshaledMsg, err := marshaler.Unmarshal(delivery)
+	require.NoError(t, err)
+
+	for _, key := range []string{"x-death_gob", "int_gob", "bool_gob"} {
+		assert.NotEmpty(t, unmarshaledMsg.Metadata.Get(key), "key %s not serialized")
+	}
+
+	assert.Empty(t, unmarshaledMsg.Metadata.Get("foo_gob"))
+}
+
+func TestDefaultMarshaler_encoded_data(t *testing.T) {
+	marshaler := amqp.DefaultMarshaler{}
+
+	delivery := createDelivery(map[string]interface{}{
+		"foo":     "bar",
+		"x-death": []interface{}{"foo", 2, true, []interface{}{"inside"}},
+		"int":     int64(3),
+		"bool":    true,
+	})
+	unmarshaledMsg, err := marshaler.Unmarshal(delivery)
+	require.NoError(t, err)
+
+	decodedHeaders := stdAmqp.Table{
+		// key foo has string value so Unmarshal not going to encode it.
+		"foo": "bar",
+	}
+
+	for _, k := range []string{"x-death_gob", "int_gob", "bool_gob"} {
+		switch k {
+		case "x-death_gob":
+			var v []interface{}
+			err := decodeValue(unmarshaledMsg.Metadata[k], &v)
+			decodedHeaders["x-death"] = v
+			assert.NoError(t, err)
+		case "int_gob":
+			var v int64
+			err := decodeValue(unmarshaledMsg.Metadata[k], &v)
+			decodedHeaders["int"] = v
+			assert.NoError(t, err)
+		case "bool_gob":
+			var v bool
+			err := decodeValue(unmarshaledMsg.Metadata[k], &v)
+			decodedHeaders["bool"] = v
+			assert.NoError(t, err)
+		}
+	}
+
+	assert.Equal(t, delivery.Headers, decodedHeaders)
+}
+
 func BenchmarkDefaultMarshaler_Marshal(b *testing.B) {
 	m := amqp.DefaultMarshaler{}
 
@@ -133,10 +193,45 @@ func BenchmarkDefaultMarshaler_Unmarshal(b *testing.B) {
 	assert.NoError(b, err)
 }
 
+func BenchmarkDefaultMarshaler_Unmarshal_Gob(b *testing.B) {
+	m := amqp.DefaultMarshaler{}
+
+	delivery := createDelivery(map[string]interface{}{
+		"foo":     "bar",
+		"x-death": []interface{}{"foo", 2, true, []interface{}{"inside"}},
+		"int":     int64(3),
+		"bool":    true,
+	})
+
+	var err error
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err = m.Unmarshal(delivery)
+	}
+	b.StopTimer()
+
+	assert.NoError(b, err)
+}
+
 func publishingToDelivery(marshaled stdAmqp.Publishing) stdAmqp.Delivery {
 	return stdAmqp.Delivery{
 		Body:          marshaled.Body,
 		Headers:       marshaled.Headers,
 		CorrelationId: marshaled.CorrelationId,
 	}
+}
+
+func createDelivery(headers map[string]interface{}) stdAmqp.Delivery {
+	return stdAmqp.Delivery{
+		Body:          []byte("payload"),
+		Headers:       headers,
+		CorrelationId: "correlation",
+	}
+}
+
+func decodeValue(value string, decodeTo interface{}) error {
+	buf := bytes.NewBuffer([]byte(value))
+	dec := gob.NewDecoder(buf)
+	err := dec.Decode(decodeTo)
+	return err
 }


### PR DESCRIPTION
Clone Issue: amqp message rejected if header is not string #65
- https://github.com/ThreeDotsLabs/watermill/issues/65